### PR TITLE
FreeBSD support

### DIFF
--- a/openntpd/config.sls
+++ b/openntpd/config.sls
@@ -5,6 +5,7 @@ openntpd-config:
     - name: {{ openntpd.conffile }}
     - source: salt://openntpd/files/ntpd.conf
     - template: jinja
+    - check_cmd: {{ openntpd.binary }} -n -f
     - watch_in:
       - service: openntpd
     - require_in:

--- a/openntpd/map.jinja
+++ b/openntpd/map.jinja
@@ -10,7 +10,7 @@
     },
     'Arch': {
         'package': 'openntpd',
-	'service': 'openntpd',
-	'conffile': '/etc/ntpd.conf',
+        'service': 'openntpd',
+        'conffile': '/etc/ntpd.conf',
     },
 }, merge=salt['pillar.get']('openntpd:lookup')) %}

--- a/openntpd/map.jinja
+++ b/openntpd/map.jinja
@@ -3,19 +3,23 @@
         'package': 'openntpd',
         'service': 'openntpd',
         'conffile': '/etc/openntpd/ntpd.conf',
+        'binary': '/usr/sbin/ntpd',
     },
     'OpenBSD': {
         'service': 'ntpd',
         'conffile': '/etc/ntpd.conf',
+        'binary': '/usr/sbin/ntpd',
     },
     'Arch': {
         'package': 'openntpd',
         'service': 'openntpd',
         'conffile': '/etc/ntpd.conf',
+        'binary': '/usr/sbin/ntpd',
     },
     'FreeBSD': {
         'package': 'openntpd',
         'service': 'openntpd',
         'conffile': '/usr/local/etc/ntpd.conf',
+        'binary': '/usr/local/sbin/ntpd',
     },
 }, merge=salt['pillar.get']('openntpd:lookup')) %}

--- a/openntpd/map.jinja
+++ b/openntpd/map.jinja
@@ -13,4 +13,9 @@
         'service': 'openntpd',
         'conffile': '/etc/ntpd.conf',
     },
+    'FreeBSD': {
+        'package': 'openntpd',
+        'service': 'openntpd',
+        'conffile': '/usr/local/etc/ntpd.conf',
+    },
 }, merge=salt['pillar.get']('openntpd:lookup')) %}

--- a/pillar.example
+++ b/pillar.example
@@ -25,6 +25,11 @@ openntpd:
 
   server: 192.168.0.2
 
+  # multiple servers:
+  server:
+    - address: 192.168.0.2
+    - address: 192.168.0.3
+
   servers:
     - address: pool.ntp.org
       weight: 2


### PR DESCRIPTION
Thanks for this great formula!

I added FreeBSD support and an example in `pillar.example`.

I'd like to add this formula to https://github.com/saltstack-formulas. OpenNTPd is missing there.
IMO it's wise to move the original repo instead of a fork. This way all maintenance work happens in a single repo and people share the workload. Do you agree?

If yes, would you like to transfer ownership to https://github.com/saltstack-formulas with you becoming a contributor? (I'm asking this as another contributor who's experience with the community there has been very good.)

If no, that's OK. I'll add my fork then. Just trying to coordinate my next steps with you. No pressure. :-)