### PR TITLE
Debian: allow to set additional service flags

### DIFF
--- a/openntpd/config.sls
+++ b/openntpd/config.sls
@@ -1,5 +1,8 @@
 {% from "openntpd/map.jinja" import openntpd with context %}
 
+include:
+  - openntpd
+
 openntpd-config:
   file.managed:
     - name: {{ openntpd.conffile }}
@@ -10,3 +13,14 @@ openntpd-config:
       - service: openntpd
     - require_in:
       - service: openntpd
+
+{%- if grains['os_family'] in ['Debian'] %}
+/etc/default/openntpd:
+  file.managed:
+    - source: salt://openntpd/files/defaults.openntpd.jinja
+    - template: jinja
+    - watch_in:
+      - service: openntpd
+    - require_in:
+      - service: openntpd
+{%  endif%}

--- a/openntpd/files/defaults.openntpd.jinja
+++ b/openntpd/files/defaults.openntpd.jinja
@@ -1,0 +1,9 @@
+### THIS FILE IS MANAGED BY SALT. ###
+{%- set additional_flags = salt['pillar.get']('openntpd:additional_flags', False) %}
+{%- set additional_flags = ' ' + additional_flags|join(' ') if additional_flags else ''%}
+# /etc/default/openntpd
+
+# Append '-s' to set the system time when starting in case the offset
+# between the local clock and the servers is more than 180 seconds.
+# For other options, see man ntpd(8).
+DAEMON_OPTS="-f /etc/openntpd/ntpd.conf{{ additional_flags }}"

--- a/pillar.example
+++ b/pillar.example
@@ -18,6 +18,8 @@ openntpd:
 --- 
 # more complexe configuration
 openntpd:
+  additional_flags:
+    - '-s'
   listen:
     - '*'
     - address: 192.168.1.55
@@ -41,4 +43,3 @@ openntpd:
       weight: 2
       refid: GPS
       stratum: 2
-


### PR DESCRIPTION
Tested on _Raspbian GNU/Linux 9.4 (stretch)_.