### PR TITLE
fix(config): handle AppArmor in check_cmd

### DIFF
--- a/openntpd/config/file.sls
+++ b/openntpd/config/file.sls
@@ -16,7 +16,14 @@ openntpd/config/install:
     - name: {{ openntpd.conffile }}
     - source: salt://openntpd/files/ntpd.conf
     - template: jinja
+# {{ openntpd | json }}
+{%  if openntpd.apparmor_enabled %}
+{%      set cfg = openntpd.conffile %}
+{%      set bak = openntpd.conffile ~ '.check_bak' %}
+    - check_cmd: sh -c 'cp {{ cfg }} {{ bak }} && cp $0 {{ cfg }} && {{ openntpd.binary }} -n -f {{ cfg }}; res=$?; mv {{ bak }} {{ cfg }}; exit $res'
+{%  else %}
     - check_cmd: {{ openntpd.binary }} -n -f
+{%  endif %}
     - user: root
     - mode: 644
     - makedirs: true

--- a/openntpd/defaults.yaml
+++ b/openntpd/defaults.yaml
@@ -6,3 +6,4 @@ openntpd:
   service: openntpd
   binary: /usr/sbin/ntpd
   conffile: /etc/openntpd/ntpd.conf
+  apparmor_enabled: False

--- a/openntpd/osfamilymap.yaml
+++ b/openntpd/osfamilymap.yaml
@@ -20,3 +20,6 @@ FreeBSD:
 
 Arch:
   conffile: /etc/ntpd.conf
+
+Debian:
+  apparmor_enabled: True

--- a/openntpd/osfingermap.yaml
+++ b/openntpd/osfingermap.yaml
@@ -10,4 +10,4 @@
 # you will need to provide at least an empty dict in this file, e.g.
 # osfingermap: {}
 ---
-osfingermap: {}
+Debian-11: {}


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [x] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->

–

### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

When a distribution uses Apparmor, `check_cmd` may not work.

The other option would be to drop `check_cmd` in those cases.

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->

–

### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->

```
% salt --state-output=changes --state-verbose=False 'my.host' state.highstate    
my.host:
----------
          ID: openntpd/config/install
    Function: file.managed
        Name: /etc/openntpd/ntpd.conf
      Result: True
     Comment: File /etc/openntpd/ntpd.conf updated
     Started: 01:02:36.892965
    Duration: 38.571 ms
     Changes:   
              ----------
              diff:
                  --- 
                  +++ 
                  @@ -1,26 +1,19 @@
                  -# $OpenBSD: ntpd.conf,v 1.14 2015/07/15 20:28:37 ajacoutot Exp $
                  -# sample ntpd configuration file, see ntpd.conf(5)
                  +# ntpd configuration file, see ntpd.conf(5)
                   
                   # Addresses to listen on (ntpd does not listen by default)
                   #listen on *
                  -#listen on 127.0.0.1
                  -#listen on ::1
                   
                   # sync to a single server
                  -#server ntp.example.org
                  +server ntp.example.org
                   
                   # use a random selection of NTP Pool Time Servers
                   # see http://support.ntp.org/bin/view/Servers/NTPPoolServers
                  -#servers pool.ntp.org
                  -
                  -# Choose servers announced from Debian NTP Pool
                  -servers 0.debian.pool.ntp.org
                  -servers 1.debian.pool.ntp.org
                  -servers 2.debian.pool.ntp.org
                  -servers 3.debian.pool.ntp.org
                  +#servers ntp.pool.ntp.org
                   
                   # use a specific local timedelta sensor (radio clock, etc)
                   #sensor nmea0
                  -
                  -# use all detected timedelta sensors
                   #sensor *
                  +#constraint from "9.9.9.9"              # quad9 v4 without DNS
                  +#constraint from "2620:fe::fe"          # quad9 v6 without DNS
                  +#constraints from "www.google.com"      # intentionally not 8.8.8.8
----------
          ID: openntpd/service/running
    Function: service.running
        Name: openntpd
      Result: True
     Comment: Service restarted
     Started: 01:02:36.979809
    Duration: 57.637 ms
     Changes:   
              ----------
              openntpd:
                  True

Summary for my.host
-------------
Succeeded: 98 (changed=2)
Failed:     0
-------------
Total states run:     98
Total run time:    4.543 s
```

### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


